### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -59,6 +59,8 @@ class ITK_TEMPLATE_EXPORT CartesianToPolarTransform :
           public Transform< TParametersValueType, NDimensions, NDimensions >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CartesianToPolarTransform);
+
   /** Standard class type alias. */
   using Self = CartesianToPolarTransform;
   using Superclass = Transform< TParametersValueType, NDimensions, NDimensions >;
@@ -161,8 +163,6 @@ protected:
   void PrintSelf(std::ostream &os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CartesianToPolarTransform);
-
   InputPointType m_Center;
 }; //class CartesianToPolarTransform
 

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -56,6 +56,8 @@ class ITK_TEMPLATE_EXPORT PolarToCartesianTransform:
   public Transform< TParametersValueType, NDimensions, NDimensions >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PolarToCartesianTransform);
+
   /** Standard class type alias. */
   using Self = PolarToCartesianTransform;
   using Superclass = Transform< TParametersValueType, NDimensions, NDimensions >;
@@ -158,8 +160,6 @@ protected:
   void PrintSelf(std::ostream &os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PolarToCartesianTransform);
-
   OutputPointType m_Center;
 }; //class PolarToCartesianTransform
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.