### PR TITLE
COMP: replace itkExceptionObject.h with itkMacro.h

### DIFF
--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -20,7 +20,7 @@
 
 #include <iostream>
 #include "itkTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMatrix.h"
 
 namespace itk

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -20,7 +20,7 @@
 
 #include <iostream>
 #include "itkTransform.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMatrix.h"
 
 namespace itk


### PR DESCRIPTION
This change was not needed with ITK-5.0.1 but seems to be needed since at least ITK @ 8c19158422e to avoid:
```
itkExceptionObject.h:19:4: error: #error "Do not include itkExceptionObject.h directly,  include itkMacro.h instead."
```