### PR TITLE
Further options for the transformations

### DIFF
--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -155,6 +155,13 @@ public:
   itkSetMacro( Center, InputPointType );
   itkGetConstReferenceMacro( Center, InputPointType );
 
+  /** Set an angular offset for the polar coordinate transform. 
+   *
+   * Defaults to 0.0
+   */
+  itkSetMacro( AngleOffset, typename OutputPointType::ValueType );
+  itkGetConstReferenceMacro( AngleOffset, typename OutputPointType::ValueType );
+
   /** Enable/Disable to use constant arc increment instead of constant angular increment.
    *
    * Defaults to Off
@@ -172,6 +179,7 @@ protected:
 
 private:
   InputPointType m_Center;
+  typename OutputPointType::ValueType m_AngleOffset = 0;
   bool m_ConstArcIncr = false;
 }; //class CartesianToPolarTransform
 

--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -155,6 +155,14 @@ public:
   itkSetMacro( Center, InputPointType );
   itkGetConstReferenceMacro( Center, InputPointType );
 
+  /** Enable/Disable to use constant arc increment instead of constant angular increment.
+   *
+   * Defaults to Off
+   */
+  itkSetMacro(ConstArcIncr, bool);
+  itkGetMacro(ConstArcIncr, bool);
+  itkBooleanMacro(ConstArcIncr);
+
 protected:
   CartesianToPolarTransform();
   ~CartesianToPolarTransform() override;
@@ -164,6 +172,7 @@ protected:
 
 private:
   InputPointType m_Center;
+  bool m_ConstArcIncr = false;
 }; //class CartesianToPolarTransform
 
 }  // namespace itk

--- a/include/itkCartesianToPolarTransform.hxx
+++ b/include/itkCartesianToPolarTransform.hxx
@@ -59,13 +59,18 @@ CartesianToPolarTransform<TParametersValueType, NDimensions>
 
   const InputPointType vector = inputPoint - this->m_Center;
 
-  outputPoint[1] = std::sqrt( vector[0] * vector[0] + vector[1] * vector[1] );
-  outputPoint[0] = std::acos( vector[0] / outputPoint[1] );
+  outputPoint[1] = std::sqrt( vector[0] * vector[0] + vector[1] * vector[1] ); // r= sqrt(x^2 + y^2)
+  outputPoint[0] = std::acos( vector[0] / outputPoint[1] ); // alpha = acos(x/r)
   if( vector[1] < 0.0 )
     {
     outputPoint[0] = Math::twopi - outputPoint[0];
     }
 
+  if(m_ConstArcIncr)
+    {
+    outputPoint[0] *= outputPoint[1]; // arc= r*alpha
+    }
+      
   return outputPoint;
 }
 

--- a/include/itkCartesianToPolarTransform.hxx
+++ b/include/itkCartesianToPolarTransform.hxx
@@ -61,6 +61,7 @@ CartesianToPolarTransform<TParametersValueType, NDimensions>
 
   outputPoint[1] = std::sqrt( vector[0] * vector[0] + vector[1] * vector[1] ); // r= sqrt(x^2 + y^2)
   outputPoint[0] = std::acos( vector[0] / outputPoint[1] ); // alpha = acos(x/r)
+  outputPoint[0] += m_AngleOffset; // add offset before 2*pi adjustment to keep values within [-pi,pi]
   if( vector[1] < 0.0 )
     {
     outputPoint[0] = Math::twopi - outputPoint[0];

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -152,6 +152,14 @@ public:
   itkSetMacro( Center, OutputPointType );
   itkGetConstReferenceMacro( Center, OutputPointType );
 
+  /** Enable/Disable to use constant arc increment instead of constant angular increment.
+   *
+   * Defaults to Off
+   */
+  itkSetMacro(ConstArcIncr, bool);
+  itkGetMacro(ConstArcIncr, bool);
+  itkBooleanMacro(ConstArcIncr);
+
 protected:
   PolarToCartesianTransform();
   ~PolarToCartesianTransform() override;
@@ -161,6 +169,7 @@ protected:
 
 private:
   OutputPointType m_Center;
+  bool m_ConstArcIncr = false;
 }; //class PolarToCartesianTransform
 
 }  // namespace itk

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -152,6 +152,13 @@ public:
   itkSetMacro( Center, OutputPointType );
   itkGetConstReferenceMacro( Center, OutputPointType );
 
+  /** Set an angular offset for the polar coordinate transform. 
+   *
+   * Defaults to 0.0
+   */
+  itkSetMacro( AngleOffset, typename InputPointType::ValueType );
+  itkGetConstReferenceMacro( AngleOffset, typename InputPointType::ValueType );
+
   /** Enable/Disable to use constant arc increment instead of constant angular increment.
    *
    * Defaults to Off
@@ -177,6 +184,7 @@ protected:
 
 private:
   OutputPointType m_Center;
+  typename InputPointType::ValueType m_AngleOffset = 0;
   bool m_ConstArcIncr = false;
   bool m_ReturnNaN = false;
 }; //class PolarToCartesianTransform

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -160,6 +160,14 @@ public:
   itkGetMacro(ConstArcIncr, bool);
   itkBooleanMacro(ConstArcIncr);
 
+  /** Enable/Disable to return NaN in case alpha is outside [-pi,pi].
+   *
+   * Defaults to Off
+   */
+  itkSetMacro(ReturnNaN, bool);
+  itkGetMacro(ReturnNaN, bool);
+  itkBooleanMacro(ReturnNaN);
+
 protected:
   PolarToCartesianTransform();
   ~PolarToCartesianTransform() override;
@@ -170,6 +178,7 @@ protected:
 private:
   OutputPointType m_Center;
   bool m_ConstArcIncr = false;
+  bool m_ReturnNaN = false;
 }; //class PolarToCartesianTransform
 
 }  // namespace itk

--- a/include/itkPolarToCartesianTransform.hxx
+++ b/include/itkPolarToCartesianTransform.hxx
@@ -56,8 +56,14 @@ PolarToCartesianTransform<TParametersValueType, NDimensions>
 {
   OutputPointType outputPoint(inputPoint);
 
-  outputPoint[0] = inputPoint[1] * std::cos(inputPoint[0]); //r*cos(alpha)
-  outputPoint[1] = inputPoint[1] * std::sin(inputPoint[0]); //r*sin(alpha)
+  double alpha = inputPoint[0];
+  if(m_ConstArcIncr)
+    {
+    alpha /= inputPoint[1]; // alpha = arc/r
+    }
+  
+  outputPoint[0] = inputPoint[1] * std::cos(alpha); //r*cos(alpha)
+  outputPoint[1] = inputPoint[1] * std::sin(alpha); //r*sin(alpha)
 
   for( unsigned int ii = 0; ii < SpaceDimension; ++ii )
     {

--- a/include/itkPolarToCartesianTransform.hxx
+++ b/include/itkPolarToCartesianTransform.hxx
@@ -61,6 +61,14 @@ PolarToCartesianTransform<TParametersValueType, NDimensions>
     {
     alpha /= inputPoint[1]; // alpha = arc/r
     }
+
+  if(m_ReturnNaN && (alpha < -Math::pi || Math::pi < alpha))
+    {
+    using PointNumericTraits = NumericTraits<typename OutputPointType::ValueType>;
+    outputPoint[0] = PointNumericTraits::quiet_NaN();
+    outputPoint[1] = PointNumericTraits::quiet_NaN();
+    return outputPoint;
+    }
   
   outputPoint[0] = inputPoint[1] * std::cos(alpha); //r*cos(alpha)
   outputPoint[1] = inputPoint[1] * std::sin(alpha); //r*sin(alpha)

--- a/include/itkPolarToCartesianTransform.hxx
+++ b/include/itkPolarToCartesianTransform.hxx
@@ -70,6 +70,8 @@ PolarToCartesianTransform<TParametersValueType, NDimensions>
     return outputPoint;
     }
   
+  alpha += m_AngleOffset; // add offset after NaN return to keep values within [-pi,pi]
+  
   outputPoint[0] = inputPoint[1] * std::cos(alpha); //r*cos(alpha)
   outputPoint[1] = inputPoint[1] * std::sin(alpha); //r*sin(alpha)
 


### PR DESCRIPTION
This PR adds the option to scale the transform with the radius. This allows to use it with the `itkResampleImageFilter` to realize a transformation from cart. coords to polar/cylindrical coords ([unfold](https://github.com/romangrothausmann/ITK-CLIs/blob/70c09a3f45df4f0c0108e6dc453732ac26e0acf8/unfold.cxx), similar to http://hdl.handle.net/10380/3605) such that the arc-length/surface area is preserved.
It also adds the option to return NaN for values outside [-pi,pi], such that `itkResampleImageFilter` uses the `DefaultPixelValue` instead of repeating the pattern periodically, and the option to specify an offset for the angle allowing to adjust the center of the output.
