### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -58,7 +58,7 @@ template <typename TParametersValueType = double, // Data type for scalars (floa
 class ITK_TEMPLATE_EXPORT CartesianToPolarTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CartesianToPolarTransform);
+  ITK_DISALLOW_COPY_AND_MOVE(CartesianToPolarTransform);
 
   /** Standard class type alias. */
   using Self = CartesianToPolarTransform;

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -56,7 +56,7 @@ template <typename TParametersValueType = double, // Data type for scalars (floa
 class ITK_TEMPLATE_EXPORT PolarToCartesianTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PolarToCartesianTransform);
+  ITK_DISALLOW_COPY_AND_MOVE(PolarToCartesianTransform);
 
   /** Standard class type alias. */
   using Self = PolarToCartesianTransform;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.