### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkCartesianToPolarTransform.hxx
+++ b/include/itkCartesianToPolarTransform.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCartesianToPolarTransform_hxx
 #define itkCartesianToPolarTransform_hxx
 
-#include "itkCartesianToPolarTransform.h"
 #include "itkMath.h"
 
 namespace itk

--- a/include/itkPolarToCartesianTransform.hxx
+++ b/include/itkPolarToCartesianTransform.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPolarToCartesianTransform_hxx
 #define itkPolarToCartesianTransform_hxx
 
-#include "itkPolarToCartesianTransform.h"
 
 namespace itk
 {

--- a/test/itkPolarTransformTest.cxx
+++ b/test/itkPolarTransformTest.cxx
@@ -58,7 +58,7 @@ itkPolarTransformTest(int, char *[])
   tmp = p2c->TransformPoint(p);
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (std::abs(tmp[i] - c[i]) > epsilon)
+    if (itk::Math::abs(tmp[i] - c[i]) > epsilon)
     {
       return EXIT_FAILURE;
     }
@@ -68,7 +68,7 @@ itkPolarTransformTest(int, char *[])
   tmp = c2p->TransformPoint(c);
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (std::abs(tmp[i] - p[i]) > epsilon)
+    if (itk::Math::abs(tmp[i] - p[i]) > epsilon)
     {
       std::cout << "Invalid cartesian to polar computed." << std::endl;
       return EXIT_FAILURE;
@@ -79,7 +79,7 @@ itkPolarTransformTest(int, char *[])
   tmp = c2p->TransformPoint(p2c->TransformPoint(p));
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (std::abs(tmp[i] - p[i]) > epsilon)
+    if (itk::Math::abs(tmp[i] - p[i]) > epsilon)
     {
       std::cout << "Invalid polar to cartesian and back computed." << std::endl;
       return EXIT_FAILURE;
@@ -90,7 +90,7 @@ itkPolarTransformTest(int, char *[])
   tmp = p2c->TransformPoint(c2p->TransformPoint(c));
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (std::abs(tmp[i] - c[i]) > epsilon)
+    if (itk::Math::abs(tmp[i] - c[i]) > epsilon)
     {
       std::cout << "Invalid cartesian to polar and back computed." << std::endl;
       return EXIT_FAILURE;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

