### PR TITLE
STYLE: Prefer using `https` instead of `http` in copyright notice

### DIFF
--- a/include/itkCartesianToPolarTransform.h
+++ b/include/itkCartesianToPolarTransform.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkCartesianToPolarTransform.hxx
+++ b/include/itkCartesianToPolarTransform.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkPolarToCartesianTransform.h
+++ b/include/itkPolarToCartesianTransform.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkPolarToCartesianTransform.hxx
+++ b/include/itkPolarToCartesianTransform.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkPolarTransformTest.cxx
+++ b/test/itkPolarTransformTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Prefer using `https` instead of `http` in copyright notice license link.

Changed in InsightSoftwareConsortium/ITK#3428

Fixes:
```
/home/runner/work/ITKPolarTransform/ITKPolarTransform/include/itkCartesianToPolarTransform.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKPolarTransform/ITKPolarTransform/include/itkCartesianToPolarTransform.hxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKPolarTransform/ITKPolarTransform/include/itkPolarToCartesianTransform.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKPolarTransform/ITKPolarTransform/include/itkPolarToCartesianTransform.hxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKPolarTransform/ITKPolarTransform/test/itkPolarTransformTest.cxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKPolarTransform/actions/runs/13094200407/job/36534462910#step:14:60