### PR TITLE
COMP: Update CI best practices and Python 3.10+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,14 +1,15 @@
-
 name: Build, test, package
 
 on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
+      itk-wheel-tag: 'v5.4.5'
+      itk-python-package-tag: 'v5.4.5'
       test-notebooks: false
-    secrets:
+    secrets: inherit

--- a/include/itkCartesianToPolarTransform.hxx
+++ b/include/itkCartesianToPolarTransform.hxx
@@ -50,7 +50,7 @@ CartesianToPolarTransform<TParametersValueType, NDimensions>::TransformPoint(con
 {
   OutputPointType outputPoint(inputPoint);
 
-  const InputPointType vector = inputPoint - this->m_Center;
+  const InputVectorType vector = inputPoint - this->m_Center;
 
   outputPoint[1] = std::sqrt(vector[0] * vector[0] + vector[1] * vector[1]); // r= sqrt(x^2 + y^2)
   outputPoint[0] = std::acos(vector[0] / outputPoint[1]);                    // alpha = acos(x/r)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "itk-core == 5.4.*",
 ]


### PR DESCRIPTION
Update clang-format linter, actions/checkout@v5, Python 3.10+, fix @ghcr-mirror refs.